### PR TITLE
import six.moves.configparser, for Python 2 compat

### DIFF
--- a/now.py
+++ b/now.py
@@ -38,7 +38,7 @@ import requests
 import base64
 import json
 import re
-import configparser
+from six.moves import configparser
 import time
 from cookielib import LWPCookieJar
 


### PR DESCRIPTION
Use six to alias configparser to ConfigParser on Python 2, so it works with AWX out of the box. Ansible core already depends on six.