### PR TITLE
Remove spurious debug output of url

### DIFF
--- a/now.py
+++ b/now.py
@@ -148,7 +148,6 @@ class NowInventory(object):
         results = []
 
         while url:
-          print >> sys.stderr, 'url:', url
           # perform REST operation, accumulating page results
           response = self.session.get(
               url, auth=self.auth, headers=self.headers, proxies={


### PR DESCRIPTION
Remove debugging output of the URL currently being processed, accidentally introduced in PR #16. Sorry...