### PR TITLE
Bugfix, create group also when there is only one tag

### DIFF
--- a/now.py
+++ b/now.py
@@ -234,7 +234,7 @@ class NowInventory(object):
 
             # groups
             for k in groups:
-                if k == "sys_tags" and record[k] != None and "," in record[k]:
+                if k == "sys_tags" and record[k] != None:
                     for y in [x.strip() for x in record[k].split(',')]:
                         self.add_group(target, y)
                 else:

--- a/now.py
+++ b/now.py
@@ -174,7 +174,7 @@ class NowInventory(object):
             return
 
         group = group.lower()
-        group = re.sub(r' ', '_', group)
+        group = re.sub(r'[^a-zA-Z0-9_]', '_', group)
 
         self.inventory.setdefault(group, {'hosts': []})
         self.inventory[group]['hosts'].append(target)


### PR DESCRIPTION

25ddb98: Previously when grouping on tags, group was only created when there where several tags on a CI.

ae6a55a: Create valid ansible group names by replacing any non-alphanumeric characters (not just a space)