### PR TITLE
Added SN_TABLE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The ServiceNow instance URI. The URI should be the fully-qualified domain name, 
 
 **`SN_USERNAME`** (required)
 
-The ServiceNow instance user name. The user acount should have enough rights to read the `cmdb_ci_server` table (default), or the table specified by SN_TABLE.
+The ServiceNow instance user name. The user acount should have enough rights to read the `cmdb_ci_server` table (default), or the table specified by `SN_TABLE`.
 
     export SN_USERNAME=user.name
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ The ServiceNow instance user password.
     export SN_PASSWORD=user.password
 
 
+**`SN_TABLE`** (optional)
+
+The ServiceNow table to query (e.g. cmdb_ci_server, cmdb_ci_netgear, cmdb_ci_win_server, etc.).
+This setting will default to `cmdb_ci_server` if not defined.
+
+    export SN_TABLE=cmdb_ci_server
+
+
 **`SN_FIELDS`** (optional)
 
 Comma seperated string providing additional table columns to add as host vars to each inventory host.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The ServiceNow instance URI. The URI should be the fully-qualified domain name, 
 
 **`SN_USERNAME`** (required)
 
-The ServiceNow instance user name. The user acount should have enough rights to read the `cmdb_ci_server` table.
+The ServiceNow instance user name. The user acount should have enough rights to read the `cmdb_ci_server` table (default), or the table specified by SN_TABLE.
 
     export SN_USERNAME=user.name
 
@@ -73,8 +73,7 @@ The ServiceNow instance user password.
 
 **`SN_TABLE`** (optional)
 
-The ServiceNow table to query (e.g. cmdb_ci_server, cmdb_ci_netgear, cmdb_ci_win_server, etc.).
-This setting will default to `cmdb_ci_server` if not defined.
+The ServiceNow table to query (e.g. cmdb_ci_server, cmdb_ci_netgear, cmdb_ci_win_server, etc.).  This setting will default to `cmdb_ci_server` if not defined.
 
     export SN_TABLE=cmdb_ci_server
 

--- a/now.ini
+++ b/now.ini
@@ -29,6 +29,10 @@ password = icanhasaccess
 
 [config]
 
+# The ServiceNow table to query (e.g. cmdb_ci_server, cmdb_ci_netgear, cmdb_ci_win_server, etc.).
+
+#table = cmdb_ci_server
+
 # NB: Do not use quotes or spaces in config parameter values.
 # Comma seperated string providing additional table columns to use as groups. Groups can overlap with fields.
 

--- a/now.py
+++ b/now.py
@@ -226,8 +226,9 @@ class NowInventory(object):
             if not selection:
                 selection = ['host_name', 'fqdn', 'ip_address']
             for k in selection:
-                if record[k] != '':
-                    target = record[k]
+                if k in record:
+                    if record[k] != '':
+                        target = record[k]
 
             # Skip if no target available
             if target is None:

--- a/now.py
+++ b/now.py
@@ -49,6 +49,7 @@ class NowInventory(object):
             hostname,
             username,
             password,
+            table=None,
             fields=None,
             groups=None,
             selection=None,
@@ -73,6 +74,9 @@ class NowInventory(object):
             pass
         self.session.cookies = self.cookies
 
+        if table is None:
+            table = 'cmdb_ci_server'
+
         if fields is None:
             fields = []
 
@@ -84,6 +88,9 @@ class NowInventory(object):
 
         if proxy is None:
             proxy = []
+
+        # table
+        self.table = table
 
         # extra fields (table columns)
         self.fields = fields
@@ -189,8 +196,6 @@ class NowInventory(object):
 
     def generate(self):
 
-        table = 'cmdb_ci_server'
-        # table = 'cmdb_ci_linux_server'
         base_fields = [
             u'name', u'host_name', u'fqdn', u'ip_address', u'sys_class_name'
         ]
@@ -199,7 +204,7 @@ class NowInventory(object):
 
         columns = list(
             set(base_fields + base_groups + self.fields + self.groups))
-        path = '/api/now/table/' + table + options + \
+        path = '/api/now/table/' + self.table + options + \
             "&sysparm_fields=" + ','.join(columns)
 
         # Default, mandatory group 'sys_class_name'
@@ -280,6 +285,11 @@ def main(args):
     if not password and config.has_option('auth', 'password'):
         password = config.get('auth', 'password')
 
+    # SN_TABLE
+    table = os.environ.get('SN_TABLE')
+    if not table and config.has_option('config', 'table'):
+        table = config.get('config', 'table')
+
     # SN_SEL_ORDER
     selection = os.environ.get("SN_SEL_ORDER", [])
 
@@ -316,6 +326,7 @@ def main(args):
         hostname=instance,
         username=username,
         password=password,
+        table=table,
         fields=fields,
         groups=groups,
         selection=selection,


### PR DESCRIPTION
Provide the option to supply the **_CI_** table similar to other options, e.g. SN_FIELDS, etc.

**_Explanation of change starting @ line 226_:**
```python
if not selection:
    selection = ['host_name', 'fqdn', 'ip_address']
for k in selection:
    if k in record:
        if record[k] != '':
            target = record[k]
```
The line ` if k in record:` handles the case where a selection_order item/field is provided that does not exist in the table.  e.g. the `cmdb_ci_netgear` table does not have a `host_name` field, which caused a KeyError:
```
Traceback (most recent call last):
  File "now.py", line 339, in <module>
    main(sys.argv)
  File "now.py", line 334, in main
    inventory.generate()
  File "now.py", line 229, in generate
    if record[k] != '':
KeyError: 'host_name'
```
Adding the ` if k in record:` avoids the KeyError