### PR TITLE
Pretty print cache for easier diffing

### DIFF
--- a/now.py
+++ b/now.py
@@ -118,7 +118,7 @@ class NowInventory(object):
                 os.makedirs(cache_dir)
             cache_file = os.path.join(cache_dir, name)
             with open(cache_file, 'w') as cache:
-                json.dump(value, cache)
+                json.dump(value, cache, indent=0, separators=(',', ': '), sort_keys=True)
 
     def _get_cache(self, name, default=None):
         cache_dir = os.environ.get('SN_CACHE_DIR')


### PR DESCRIPTION
This inserts newlines after each key/value pair in the generated `__snow_inventory__` cache, making it possible to diff with an earlier version. This is useful when debugging script development, effects of config file changes, or just to have a record of your changing inventory over time---especially if the cache is committed to version control. On a 5MB file I measured about 150KB of newlines, or a 3% increase. It does not indent the result, as it's not useful for diffing and wastes too much space.

Keys under each host are also sorted to keep the output stable and diff-able. No sorting of hosts is done (by name or sys_id) because in practice the host order returned by ServiceNow is stable.