### PR TITLE
Fix 'DeprecationWarning: The SafeConfigParser renamed...ConfigParser in Python 3.2

### DIFF
--- a/now.py
+++ b/now.py
@@ -271,7 +271,7 @@ def main(args):
     # username = os.environ['SN_USERNAME']
     # password = os.environ['SN_PASSWORD']
     global config
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
 
     if os.environ.get('NOW_INI', ''):
         config_files = [os.environ['NOW_INI']]


### PR DESCRIPTION
Eliminate/Fix deprecation warning that first appeared when switching to Python 3.8.2.

```
# ansible 127.0.0.1  -i inventory/now.py -m ping
 [ERROR]: /var/lib/awx/projects/net_compliance/inventory/now.py:293: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be
removed in future versions. Use ConfigParser directly instead.   config = configparser.SafeConfigParser()
127.0.0.1 | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
```